### PR TITLE
Don't use SSLv3 health-check to avoid unnecessary warnings in the backend

### DIFF
--- a/haproxy.tmpl
+++ b/haproxy.tmpl
@@ -11,19 +11,6 @@
         {{ end }}
 {{ end }}
 
-{{ define "https_upstream" }}
-        {{ if .Address }}
-                {{/* If port is not published on host, use container's IP:PORT */}}
-                {{ if .Address.IP }}
-                        # {{ .Container.Name }}
-                        server {{ .Address.IP }}:{{ .Address.Port }} {{ .Address.IP }}:{{ .Address.Port }} ssl verify none check
-                {{ else }}
-                        # {{ .Container.Name }}
-                        server {{ .Container.Name }}:{{ .Address.Port }} {{ .Container.Name }}:{{ .Address.Port }} ssl verify none check
-                {{ end }}
-        {{ end }}
-{{ end }}
-
 global
 	daemon
 	maxconn 1024
@@ -105,9 +92,9 @@ backend https_{{$host}}
 	stick store-response payload_lv(43,1) if serverhello
 
 	option tcp-check
-
+  
 	{{ $address := where $container.Addresses "Port" $https_port | first }}
-	{{ template "https_upstream" (dict "Container" $container "Address" $address) }}
+	{{ template "upstream" (dict "Container" $container "Address" $address) }}
 {{end}}
 
 {{range $key, $container := whereExist $ "Env.LAGOON_LOCALDEV_HTTP_PORT" }}

--- a/haproxy.tmpl
+++ b/haproxy.tmpl
@@ -11,6 +11,19 @@
         {{ end }}
 {{ end }}
 
+{{ define "https_upstream" }}
+        {{ if .Address }}
+                {{/* If port is not published on host, use container's IP:PORT */}}
+                {{ if .Address.IP }}
+                        # {{ .Container.Name }}
+                        server {{ .Address.IP }}:{{ .Address.Port }} {{ .Address.IP }}:{{ .Address.Port }} ssl verify none check
+                {{ else }}
+                        # {{ .Container.Name }}
+                        server {{ .Container.Name }}:{{ .Address.Port }} {{ .Container.Name }}:{{ .Address.Port }} ssl verify none check
+                {{ end }}
+        {{ end }}
+{{ end }}
+
 global
 	daemon
 	maxconn 1024
@@ -91,10 +104,10 @@ backend https_{{$host}}
 	# Learn on response if server hello.
 	stick store-response payload_lv(43,1) if serverhello
 
-	option ssl-hello-chk
+	option tcp-check
 
 	{{ $address := where $container.Addresses "Port" $https_port | first }}
-	{{ template "upstream" (dict "Container" $container "Address" $address) }}
+	{{ template "https_upstream" (dict "Container" $container "Address" $address) }}
 {{end}}
 
 {{range $key, $container := whereExist $ "Env.LAGOON_LOCALDEV_HTTP_PORT" }}


### PR DESCRIPTION
The option <code>option ssl-hello-chk</code> uses deprecated SSLv3. If your upstream server is logging on a sensitive level the health checks fill the error / access logs e.g. nginx with log level <code>warn</code>.

The adjusted config seems to work - even thought I've no freaking clue what I'm doing 😛 