### PR TITLE
Use unique namespacing for $host values

### DIFF
--- a/haproxy.tmpl
+++ b/haproxy.tmpl
@@ -43,7 +43,7 @@ frontend http
 {{range $key, $container := whereExist $ "Env.LAGOON_LOCALDEV_HTTP_PORT" }}
   {{/* Allow containers to set their hostname via the env variable LAGOON_ROUTE if not set, fall back to the container name and projectname. Also remove http:// and https:// */}}
   {{$host := replace (replace (coalesce $container.Env.LAGOON_LOCALDEV_URL $container.Env.LAGOON_ROUTE  (printf "%s.docker.amazee.io" $container.Name)) "http://" "" 1) "https://" "" 1 }}
-  use_backend http_{{$host}} if { hdr_dom(host) -i {{$host}} }
+  use_backend http_{{$container.Name}} if { hdr_dom(host) -i {{$host}} }
 {{end}}
 
 frontend https
@@ -58,7 +58,7 @@ frontend https
 {{range $key, $container := whereExist $ "Env.LAGOON_LOCALDEV_HTTP_PORT" }}
   {{/* Allow containers to set their hostname via the env variable LAGOON_ROUTE if not set, fall back to the container name and projectname. Also remove http:// and https:// */}}
   {{$host := replace (replace (coalesce $container.Env.LAGOON_LOCALDEV_URL $container.Env.LAGOON_ROUTE  (printf "%s.docker.amazee.io" $container.Name)) "http://" "" 1) "https://" "" 1 }}
-  use_backend http_{{$host}} if { hdr_dom(host) -i {{$host}} }
+  use_backend http_{{$container.Name}} if { hdr_dom(host) -i {{$host}} }
 {{end}}
 
 {{range $key, $container := whereExist $ "Env.AMAZEEIO" }}
@@ -75,7 +75,7 @@ backend http_{{$host}}
   {{$host := replace (replace (coalesce $container.Env.LAGOON_LOCALDEV_URL $container.Env.LAGOON_ROUTE  (printf "%s.docker.amazee.io" $container.Name)) "http://" "" 1) "https://" "" 1 }}
   {{/* Allow containers to set their the port for HTTP connections via LAGOON_LOCALDEV_HTTP_PORT env variable, fallback to Port 8080 */}}
   {{$http_port := coalesce $container.Env.LAGOON_LOCALDEV_HTTP_PORT "8080" }}
-backend http_{{$host}}
+backend http_{{$container.Name}}
   mode http
   {{ $address := where $container.Addresses "Port" $http_port | first }}
   {{ template "upstream" (dict "Container" $container "Address" $address) }}


### PR DESCRIPTION
After using this image via pygmy, I was unable to restart the service or add to it due to what appeared to be a namespacing problem.

The following was outputted using the provided shell scripts to start and restart the service, in addition to restarting the container. This means multiple docker-compose projects cannot be run simultaneously (ie `site1.docker.amazee.io`, `site2.docker.amazee.io`), or a single set cannot be accessed via HAProxy after the container is restarted.

(Note: this was presented without _any_ additional configuration or customisation to the [drupal example](https://github.com/amazeeio/drupal-example).)

```
[ALERT] 205/034444 (51) : Parsing [/app/haproxy.cfg:38]: backend 'http_site1.docker.amazee.io' has the same name as backend 'http_site1.docker.amazee.io' declared at /app/haproxy.cfg:34.
[ALERT] 205/034444 (51) : Error(s) found in configuration file : /app/haproxy.cfg
[ALERT] 205/034444 (51) : Fatal errors found in configuration.
```

This PR proposes to fix the namespacing problem identified by instead using a namespace value matching the container name which is a globally unique value.

This is particularly notable when nginx and varnish are delegated an identical `$host` value, which is the problem this PR solves.

You can see the docker automated build for this at https://hub.docker.com/r/fubarhouse/docker-haproxy/builds/bpfw5y5ftafnykkfannitcd/

> People wanting to test this out can change the pygmy image path reference to use 
`fubarhouse/docker-haproxy:feature_namespace-fix` under the library reference at `lib/pygmy/haproxy.rb` under the installation path of pygmy.