### PR TITLE
Add /stats to https configuration

### DIFF
--- a/haproxy.tmpl
+++ b/haproxy.tmpl
@@ -51,6 +51,11 @@ frontend https
   bind *:443 ssl crt /app/server.pem
   reqadd X-Forwarded-Proto:\ https
   option socket-stats
+
+  stats enable
+  stats refresh 30s
+  stats show-node
+  stats uri  /stats
 {{range $key, $container := whereExist $ "Env.AMAZEEIO" }}
         {{$host := coalesce $container.Env.AMAZEEIO_URL $container.Name }}
   use_backend http_{{$host}} if { hdr_dom(host) -i {{$host}} }


### PR DESCRIPTION
The stats page isn't present when haproxy isn't set up for https.

Though the container can be run to expose `80` or `443`, the stats page will only be present when accessing via port `80` - assuming it is configured. If somebody is running exclusively on port `443` the stats page becomes unavailable - so the port would need to be reassigned independent of trying to access the stats page.

This PR simply copies the configuration of http for the `/stats` page for https.