### PR TITLE
Update haproxy to v2.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM haproxy:1.7-alpine
+FROM haproxy:2.1-alpine
 
 RUN apk update && apk --no-cache add bash
 

--- a/haproxy.tmpl
+++ b/haproxy.tmpl
@@ -49,7 +49,7 @@ frontend http
 frontend https
   mode http
   bind *:443 ssl crt /app/server.pem
-  reqadd X-Forwarded-Proto:\ https
+  http-request add-header X-Forwarded-Proto https
   option socket-stats
 {{range $key, $container := whereExist $ "Env.AMAZEEIO" }}
         {{$host := coalesce $container.Env.AMAZEEIO_URL $container.Name }}


### PR DESCRIPTION
Updates `haproxy` to `v2.1` and replaces deprecated `reqadd` for relevant alternative for port 443.