### PR TITLE
Prepared for multi-arch Docker image build, with updated docker-gen

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM haproxy:1.7-alpine
+FROM haproxy:2.2-alpine
 
 RUN apk update && apk --no-cache add bash
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
 FROM haproxy:2.2-alpine
 
-RUN apk update && apk --no-cache add bash
+RUN apk update && apk --no-cache add bash curl
 
-ENV DOCKER_GEN_VERSION 0.7.3
+ENV DOCKER_GEN_VERSION 0.7.6
 
-ADD https://github.com/jwilder/docker-gen/releases/download/$DOCKER_GEN_VERSION/docker-gen-linux-amd64-$DOCKER_GEN_VERSION.tar.gz /tmp/docker-gen.tar.gz
-
-RUN tar -C /usr/local/bin -xvzf /tmp/docker-gen.tar.gz && \
-    chmod +x /usr/local/bin/docker-gen
+RUN ARCH=$(case $(uname -m) in i386 | i686 | x86) echo "i386" ;; x86_64 | amd64) echo "amd64" ;; aarch64 | arm64 | armv8) echo "arm64" ;; *) echo "amd64" ;; esac) \
+    && curl -A "Docker" -o /tmp/docker-gen.tar.gz -D - -L -s https://github.com/jwilder/docker-gen/releases/download/$DOCKER_GEN_VERSION/docker-gen-linux-$ARCH-$DOCKER_GEN_VERSION.tar.gz \
+    && tar -C /usr/local/bin -xvzf /tmp/docker-gen.tar.gz \
+    && chmod +x /usr/local/bin/docker-gen
 
 COPY . /app/
 WORKDIR /app/

--- a/haproxy.tmpl
+++ b/haproxy.tmpl
@@ -49,7 +49,7 @@ frontend http
 frontend https
   mode http
   bind *:443 ssl crt /app/server.pem
-  reqadd X-Forwarded-Proto:\ https
+  http-request add-header X-Forwarded-Proto https
   option socket-stats
 {{range $key, $container := whereExist $ "Env.AMAZEEIO" }}
         {{$host := coalesce $container.Env.AMAZEEIO_URL $container.Name }}


### PR DESCRIPTION
In order to get the `pygmy` stack [running on my Apple M1](https://github.com/amazeeio/lagoon/issues/2521) arm64 machine, I had to rebuild this image as `linux/arm64`, which also involved creating Go cross-compiled versions of the `docker-gen` tool. I went to put in a PR to the original `docker-gen` repo, but several people have already put in requests for cross-compiled versions of the binaries, and the repo hasn't been touched since 2018.

See my updated version of [`docker-gen` here](https://github.com/ocean/docker-gen).

This updated `Dockerfile` can be built into a [multi-arch image version](https://docs.docker.com/buildx/working-with-buildx/) for Docker Hub using these steps:

1. Create a Docker BuildKit build image by running:
    `$ docker buildx create --use --name=multi`
   Docker will download and run the `moby/buildkit` image.
2. Build and push the images for 2 architectures by running:
    `$ docker buildx build --platform linux/amd64,linux/arm64 --push -t amazeeio/haproxy -f ./Dockerfile .`