### PR TITLE
Maintenance updates: haproxy 2.3, docker-gen 0.7.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM haproxy:1.7-alpine
+FROM haproxy:2.2-alpine
 
 RUN apk update && apk --no-cache add bash
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM haproxy:2.2-alpine
 
 RUN apk update && apk --no-cache add bash
 
-ENV DOCKER_GEN_VERSION 0.7.3
+ENV DOCKER_GEN_VERSION 0.7.4
 
 ADD https://github.com/jwilder/docker-gen/releases/download/$DOCKER_GEN_VERSION/docker-gen-linux-amd64-$DOCKER_GEN_VERSION.tar.gz /tmp/docker-gen.tar.gz
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM haproxy:2.3-alpine
 
 RUN apk update && apk --no-cache add bash
 
-ENV DOCKER_GEN_VERSION 0.7.4
+ENV DOCKER_GEN_VERSION 0.7.6
 
 ADD https://github.com/jwilder/docker-gen/releases/download/$DOCKER_GEN_VERSION/docker-gen-linux-amd64-$DOCKER_GEN_VERSION.tar.gz /tmp/docker-gen.tar.gz
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM haproxy:2.2-alpine
+FROM haproxy:2.3-alpine
 
 RUN apk update && apk --no-cache add bash
 

--- a/haproxy.tmpl
+++ b/haproxy.tmpl
@@ -23,7 +23,6 @@ defaults
   timeout server 600s
   option http-server-close
 
-
 frontend http
   mode http
   bind :80
@@ -49,7 +48,7 @@ frontend http
 frontend https
   mode http
   bind *:443 ssl crt /app/server.pem
-  reqadd X-Forwarded-Proto:\ https
+  http-request add-header X-Forwarded-Proto https
   option socket-stats
 {{range $key, $container := whereExist $ "Env.AMAZEEIO" }}
         {{$host := coalesce $container.Env.AMAZEEIO_URL $container.Name }}


### PR DESCRIPTION
* Updates haproxy from v1.7 to v2.3
* Updates docker-gen from v0.7.3 to 0.7.6
* Updates are focused at supporting Apple M1 architecture.